### PR TITLE
feat: add enough context to plugin methods to figure out bench task name

### DIFF
--- a/lib/clock.js
+++ b/lib/clock.js
@@ -224,7 +224,7 @@ async function clockBenchmark(bench, recommendedCount) {
   result[0] = Math.max(MIN_RESOLUTION, result[0]);
   for (const p of bench.plugins) {
     if (typeof p.onCompleteBenchmark === 'function') {
-      p.onCompleteBenchmark(result);
+      p.onCompleteBenchmark(result, bench);
     }
   }
 

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -11,13 +11,13 @@ function getItersForOpDuration(durationPerOp, targetTime) {
   return Math.min(Number.MAX_SAFE_INTEGER, Math.max(1, Math.round(totalOpsForMinTime)));
 }
 
-function parsePluginsResult(plugins) {
+function parsePluginsResult(plugins, name) {
   const result = []
   for (const p of plugins) {
     result.push({
       name: p.toString(),
-      result: p.getResult?.() ?? 'enabled',
-      report: p.getReport?.() ?? '',
+      result: p.getResult?.(name) ?? 'enabled',
+      report: p.getReport?.(name) ?? '',
     });
   }
   return result;
@@ -97,7 +97,7 @@ async function runBenchmark(bench, initialIterations) {
     iterations,
     histogram,
     name: bench.name,
-    plugins: parsePluginsResult(bench.plugins),
+    plugins: parsePluginsResult(bench.plugins, bench.name),
   };
 }
 


### PR DESCRIPTION
fix #19 

not sure about passing the entire bench vs just the name. 

noticed toJSON show up on the list of methods called, might be a result of something else being added :shrug: 