### PR TITLE
feat: add min samples as param 

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ const suite = new Suite({ reporter: false });
   * `minTime` {number} Minimum duration for the benchmark to run. **Default:** `0.05` seconds.
   * `maxTime` {number} Maximum duration for the benchmark to run. **Default:** `0.5` seconds.
   * `repeatSuite` {number} Number of times to repeat benchmark to run. **Default:** `1` times.
+  * `minSamples` {number} Number minimum of samples the each round. **Default:** `10` samples.
 * `fn` {Function|AsyncFunction} The benchmark function. Can be synchronous or asynchronous. 
 * Returns: {Suite}
 

--- a/examples/create-uint32array/node.js
+++ b/examples/create-uint32array/node.js
@@ -9,6 +9,9 @@ suite
   .add(`new Uint32Array(1024) with 10 repetitions`,  {repeatSuite: 10}, function () {
     return new Uint32Array(1024);
   })
+  .add(`new Uint32Array(1024) with min samples of 50`, {minSamples: 50}, function() {
+    return new Uint32Array(1024);
+  })
   .add(`[Managed] new Uint32Array(1024)`, function (timer) {
     const assert = require('node:assert');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ const defaultBenchOptions = {
 	// Number of times the benchmark will be repeated
 	repeatSuite: 1,
 	// Number minimum of samples the each round
-	minSamples: 10
+	minSamples: 10,
 };
 
 function throwIfNoNativesSyntax() {
@@ -152,7 +152,7 @@ class Suite {
 			options.maxTime,
 			this.#plugins,
 			options.repeatSuite,
-			options.minSamples
+			options.minSamples,
 		);
 		this.#benchmarks.push(benchmark);
 		return this;
@@ -195,7 +195,7 @@ class Suite {
 					benchmark,
 					initialIterations,
 					benchmark.repeatSuite,
-					benchmark.minSamples
+					benchmark.minSamples,
 				);
 			}
 			results[i] = result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ const defaultBenchOptions = {
 	maxTime: 0.5,
 	// Number of times the benchmark will be repeated
 	repeatSuite: 1,
-	// Number of min samples in each suite was run
+	// Number minimum of samples the each round
 	minSamples: 10
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,14 +39,16 @@ class Benchmark {
 	maxTime;
 	plugins;
 	repeatSuite;
+	minSamples;
 
-	constructor(name, fn, minTime, maxTime, plugins, repeatSuite) {
+	constructor(name, fn, minTime, maxTime, plugins, repeatSuite, minSamples) {
 		this.name = name;
 		this.fn = fn;
 		this.minTime = minTime;
 		this.maxTime = maxTime;
 		this.plugins = plugins;
 		this.repeatSuite = repeatSuite;
+		this.minSamples = minSamples;
 
 		this.hasArg = this.fn.length >= 1;
 		if (this.fn.length > 1) {
@@ -75,6 +77,8 @@ const defaultBenchOptions = {
 	maxTime: 0.5,
 	// Number of times the benchmark will be repeated
 	repeatSuite: 1,
+	// Number of min samples in each suite was run
+	minSamples: 10
 };
 
 function throwIfNoNativesSyntax() {
@@ -133,6 +137,11 @@ class Suite {
 				"options.repeatSuite",
 				options.repeatSuite,
 			);
+			validateNumber(
+				options.minSamples,
+				"options.minSamples",
+				options.minSamples,
+			);
 		}
 		validateFunction(fn, "fn");
 
@@ -143,6 +152,7 @@ class Suite {
 			options.maxTime,
 			this.#plugins,
 			options.repeatSuite,
+			options.minSamples
 		);
 		this.#benchmarks.push(benchmark);
 		return this;
@@ -174,7 +184,7 @@ class Suite {
 			// Warmup is calculated to reduce noise/bias on the results
 			const initialIterations = await getInitialIterations(benchmark);
 			debugBench(
-				`Starting ${benchmark.name} with minTime=${benchmark.minTime}, maxTime=${benchmark.maxTime}, repeatSuite=${benchmark.repeatSuite}`,
+				`Starting ${benchmark.name} with minTime=${benchmark.minTime}, maxTime=${benchmark.maxTime}, repeatSuite=${benchmark.repeatSuite}, minSamples=${benchmark.minSamples}`,
 			);
 
 			let result;
@@ -185,6 +195,7 @@ class Suite {
 					benchmark,
 					initialIterations,
 					benchmark.repeatSuite,
+					benchmark.minSamples
 				);
 			}
 			results[i] = result;
@@ -204,6 +215,7 @@ class Suite {
 			benchmark,
 			initialIterations,
 			repeatSuite: benchmark.repeatSuite,
+			minSamples: benchmark.minSamples,
 		});
 		return new Promise((resolve, reject) => {
 			worker.on("message", (result) => {

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -114,15 +114,13 @@ async function runBenchmarkOnce(
 	return { iterations, timeSpent };
 }
 
-async function runBenchmark(bench, initialIterations, repeatSuite) {
+async function runBenchmark(bench, initialIterations, repeatSuite, minSamples) {
 	const histogram = new StatisticalHistogram();
 
 	const maxDuration = bench.maxTime * timer.scale;
-	const minSamples = 10;
 
 	let totalIterations = 0;
 	let totalTimeSpent = 0;
-
 	for (let i = 0; i < repeatSuite; ++i) {
 		const { iterations, timeSpent } = await runBenchmarkOnce(bench, histogram, {
 			initialIterations,

--- a/test/basic.js
+++ b/test/basic.js
@@ -160,6 +160,19 @@ describe("API Interface", () => {
 				);
 			}
 		});
+
+		it("minSamples should be a valid number", () => {
+			for (const r of ["ds", {}, () => {}]) {
+				assert.throws(
+					() => {
+						bench.add("name", { minSamples: r }, noop);
+					},
+					{
+						code: "ERR_INVALID_ARG_TYPE",
+					},
+				);
+			}
+		});
 	});
 });
 

--- a/test/plugin-api-doc.js
+++ b/test/plugin-api-doc.js
@@ -67,7 +67,7 @@ describe("plugin API", async () => {
       "getReport(string)",
       "getResult(string)",
       "isSupported()",
-      "onCompleteBenchmark([number, number, object], {fn, fnStr, hasArg, isAsync, maxTime, minTime, name, plugins, repeatSuite})",
+      "onCompleteBenchmark([number, number, object], {fn, fnStr, hasArg, isAsync, maxTime, minSamples, minTime, name, plugins, repeatSuite})",
       "toJSON(string)",
       "toString()",
     ]);


### PR DESCRIPTION
Hey, this PR enables users to pass minSamples as opts, it's related to issue https://github.com/RafaelGSS/bench-node/issues/30

Below, you’ll check the difference using minSamples in the third run:

![image](https://github.com/user-attachments/assets/e49fa04c-7327-4862-9ef7-7376571ea275)

Thanks :)