### PR TITLE
Expose histogram sample data to custom reporters

### DIFF
--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -134,14 +134,17 @@ async function runBenchmark(bench, initialIterations, repeatSuite, minSamples) {
 
 	const opsSec = totalIterations / (totalTimeSpent / timer.scale);
 
+	const sampleData = histogram.samples;
+
 	return {
 		opsSec,
 		iterations: totalIterations,
 		// StatisticalHistogram is not a serializable object
 		histogram: {
-			samples: histogram.samples.length,
+			samples: sampleData.length,
 			min: histogram.min,
 			max: histogram.max,
+			sampleData,
 		},
 		name: bench.name,
 		plugins: parsePluginsResult(bench.plugins, bench.name),


### PR DESCRIPTION
This PR adds a `.all` property to each object in the results array passed to custom reporters, which contains an array of the histogram sample data for that benchmark result.

Fixes RafaelGSS/bench-node#66.