### PR TITLE
feat: add time mode benchmark

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,8 @@
 		"rules": {
 			"recommended": true,
 			"style": {
-				"noParameterAssign": "off"
+				"noParameterAssign": "off",
+				"noUselessElse": "off"
 			}
 		}
 	},

--- a/examples/time-mode.js
+++ b/examples/time-mode.js
@@ -1,0 +1,28 @@
+const { Suite } = require('../lib');
+
+const timeSuite = new Suite({
+    benchmarkMode: 'time' // Set mode for the entire suite
+});
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+timeSuite.add('Async Delay 100ms (time)', async () => {
+    await delay(100);
+});
+
+timeSuite.add('Sync Busy Wait 50ms (time)', () => {
+    const start = Date.now();
+    while (Date.now() - start < 50);
+});
+
+timeSuite.add('Quick Sync Op with 5 repeats (time)', { repeatSuite: 5 }, () => {
+    // This will run exactly once per repeat (5 times total)
+    // and report the average time
+    let x = 1 + 1;
+});
+
+
+(async () => {
+    console.log('\nRunning benchmark suite in TIME mode...');
+    await timeSuite.run();
+})();

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -233,11 +233,21 @@ function createRunner(bench, recommendedCount) {
 	return runner;
 }
 
-async function clockBenchmark(bench, recommendedCount) {
+/**
+ * Executes a benchmark and returns the time taken and number of iterations
+ * @param {import('./index').Benchmark} bench - The benchmark to execute
+ * @param {number} recommendedCount - The recommended number of iterations
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.timeMode=false] - If true, runs the benchmark exactly once
+ * @returns {Promise<[number, number]>} - Returns [duration, iterations]
+ */
+async function clockBenchmark(bench, recommendedCount, options = {}) {
 	const runner = createRunner(bench, recommendedCount);
 	const result = await runner();
+
 	// Just to avoid issues with empty fn
 	result[0] = Math.max(MIN_RESOLUTION, result[0]);
+
 	for (const p of bench.plugins) {
 		if (typeof p.onCompleteBenchmark === "function") {
 			// TODO: this won't work when useWorkers=true
@@ -246,7 +256,7 @@ async function clockBenchmark(bench, recommendedCount) {
 	}
 
 	debugBench(
-		`Took ${timer.format(result[0])} to execute ${result[1]} iterations`,
+		`Took ${timer.format(result[0])} to execute ${result[1]} iterations${options.timeMode ? " (time mode)" : ""}`,
 	);
 	return result;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ const {
 	validateObject,
 	validateString,
 	validateArray,
+	validateBenchmarkMode,
 } = require("./validators");
 
 const getFunctionBody = (string) =>
@@ -94,10 +95,12 @@ class Suite {
 	#reporter;
 	#plugins;
 	#useWorkers;
+	#benchmarkMode;
 
 	constructor(options = {}) {
 		this.#benchmarks = [];
 		validateObject(options, "options");
+
 		if (options?.reporter !== undefined) {
 			if (options?.reporter !== false && options?.reporter !== null) {
 				validateFunction(options.reporter, "reporter");
@@ -108,11 +111,16 @@ class Suite {
 		}
 
 		this.#useWorkers = options.useWorkers || false;
+
 		if (options?.plugins) {
 			validateArray(options.plugins, "plugin");
 			validatePlugins(options.plugins);
 		}
 		this.#plugins = options?.plugins || [new V8NeverOptimizePlugin()];
+
+		// Benchmark Mode setup
+		this.#benchmarkMode = options.benchmarkMode || "ops"; // Default to 'ops'
+		validateBenchmarkMode(this.#benchmarkMode, "options.benchmarkMode");
 	}
 
 	add(name, options, fn) {
@@ -184,16 +192,22 @@ class Suite {
 			// Warmup is calculated to reduce noise/bias on the results
 			const initialIterations = await getInitialIterations(benchmark);
 			debugBench(
-				`Starting ${benchmark.name} with minTime=${benchmark.minTime}, maxTime=${benchmark.maxTime}, repeatSuite=${benchmark.repeatSuite}, minSamples=${benchmark.minSamples}`,
+				`Starting ${benchmark.name} with mode=${this.#benchmarkMode}, minTime=${benchmark.minTime}, maxTime=${benchmark.maxTime}, repeatSuite=${benchmark.repeatSuite}, minSamples=${benchmark.minSamples}`,
 			);
 
 			let result;
 			if (this.#useWorkers) {
+				if (this.#benchmarkMode === "time") {
+					console.warn(
+						"Warning: Worker mode currently doesn't fully support 'time' benchmarkMode.",
+					);
+				}
 				result = await this.runWorkerBenchmark(benchmark, initialIterations);
 			} else {
 				result = await runBenchmark(
 					benchmark,
 					initialIterations,
+					this.#benchmarkMode,
 					benchmark.repeatSuite,
 					benchmark.minSamples,
 				);
@@ -204,35 +218,35 @@ class Suite {
 		if (this.#reporter) {
 			this.#reporter(results);
 		}
+
 		return results;
 	}
 
-	runWorkerBenchmark(benchmark, initialIterations) {
-		benchmark.serializeBenchmark();
-		const worker = new Worker(path.join(__dirname, "./worker-runner.js"));
-
-		worker.postMessage({
-			benchmark,
-			initialIterations,
-			repeatSuite: benchmark.repeatSuite,
-			minSamples: benchmark.minSamples,
-		});
+	async runWorkerBenchmark(benchmark, initialIterations) {
 		return new Promise((resolve, reject) => {
+			const workerPath = path.resolve(__dirname, "./worker-runner.js");
+			const worker = new Worker(workerPath);
+
+			benchmark.serializeBenchmark();
+			worker.postMessage({
+				benchmark,
+				initialIterations,
+				benchmarkMode: this.#benchmarkMode, // Pass suite mode
+				repeatSuite: benchmark.repeatSuite,
+				minSamples: benchmark.minSamples,
+			});
+
 			worker.on("message", (result) => {
 				resolve(result);
-				// TODO: await?
 				worker.terminate();
 			});
-
-			worker.on("error", (err) => {
-				reject(err);
+			worker.on("error", (error) => {
+				reject(error);
 				worker.terminate();
 			});
-
 			worker.on("exit", (code) => {
-				if (code !== 0) {
+				if (code !== 0)
 					reject(new Error(`Worker stopped with exit code ${code}`));
-				}
 			});
 		});
 	}

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -100,9 +100,24 @@ async function runBenchmarkOnce(
 	bench,
 	histogram,
 	{ initialIterations, maxDuration, minSamples },
+	benchmarkMode = "ops",
 ) {
 	let iterations = 0;
 	let timeSpent = 0;
+
+	// For time mode, we want to run the benchmark exactly once
+	if (benchmarkMode === "time") {
+		const { 0: duration, 1: realIterations } = await clockBenchmark(bench, 1);
+		timeSpent = duration;
+		iterations = realIterations;
+
+		// Record the duration in the histogram
+		histogram.record(duration);
+
+		return { iterations, timeSpent };
+	}
+
+	// Ops mode - run the sampling loop
 	while (timeSpent < maxDuration || histogram.samples.length <= minSamples) {
 		const { 0: duration, 1: realIterations } = await clockBenchmark(
 			bench,
@@ -132,36 +147,47 @@ async function runBenchmarkOnce(
  * Executes a benchmark with the specified parameters
  * @param {import('./index').Benchmark} bench - The benchmark object to be executed
  * @param {number} initialIterations - The initial number of iterations to run
+ * @param {string} benchmarkMode - The benchmark mode ('ops' or 'time')
  * @param {number} repeatSuite - Number of times to repeat the benchmark suite
  * @param {number} minSamples - Minimum number of samples to collect
- * @returns {Promise<Object>} The benchmark results containing operations per second, iterations, histogram data and plugin results
+ * @returns {Promise<Object>} The benchmark results containing operations per second or total time, iterations, histogram data and plugin results
  */
-async function runBenchmark(bench, initialIterations, repeatSuite, minSamples) {
+async function runBenchmark(
+	bench,
+	initialIterations,
+	benchmarkMode,
+	repeatSuite,
+	minSamples,
+) {
 	const histogram = new StatisticalHistogram();
-
 	const maxDuration = bench.maxTime * timer.scale;
 
 	let totalIterations = 0;
 	let totalTimeSpent = 0;
 	for (let i = 0; i < repeatSuite; ++i) {
-		const { iterations, timeSpent } = await runBenchmarkOnce(bench, histogram, {
-			initialIterations,
-			maxDuration,
-			minSamples,
-		});
+		const { iterations, timeSpent } = await runBenchmarkOnce(
+			bench,
+			histogram,
+			{
+				initialIterations,
+				maxDuration,
+				minSamples,
+			},
+			benchmarkMode,
+		);
 		totalTimeSpent += timeSpent;
 		totalIterations += iterations;
 	}
 	histogram.finish();
 
 	const opsSec = totalIterations / (totalTimeSpent / timer.scale);
+	const totalTime = totalTimeSpent / timer.scale; // Convert ns to seconds
 
 	const sampleData = histogram.samples;
 
-	return {
-		opsSec,
+	const result = {
 		iterations: totalIterations,
-		// StatisticalHistogram is not a serializable object
+		// StatisticalHistogram is not a serializable object, keep raw ns for min/max
 		histogram: {
 			samples: sampleData.length,
 			min: histogram.min,
@@ -171,6 +197,21 @@ async function runBenchmark(bench, initialIterations, repeatSuite, minSamples) {
 		name: bench.name,
 		plugins: parsePluginsResult(bench.plugins, bench.name),
 	};
+
+	// Add the appropriate metric based on the benchmark mode
+	if (benchmarkMode === "time") {
+		result.totalTime = totalTime / repeatSuite; // Average time per repeat
+		debugBench(
+			`${bench.name} completed ${repeatSuite} repeats with average time ${result.totalTime.toFixed(6)} seconds`,
+		);
+	} else {
+		result.opsSec = opsSec;
+		debugBench(
+			`${bench.name} completed ${sampleData.length} samples with ${opsSec.toFixed(2)} ops/sec`,
+		);
+	}
+
+	return result;
 }
 
 module.exports = {

--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -6,28 +6,58 @@ const formatter = Intl.NumberFormat(undefined, {
 	maximumFractionDigits: 2,
 });
 
+const timer = Intl.NumberFormat(undefined, {
+	minimumFractionDigits: 3,
+	maximumFractionDigits: 3,
+});
+
 /**
  * Draws a bar chart representation of a benchmark result
  * @param {string} label - The label for the bar (benchmark name)
- * @param {number} value - The value to display (operations per second)
+ * @param {number} value - The value to display (operations per second or time per operation)
  * @param {number} total - The maximum value in the dataset (for scaling)
  * @param {number} samples - Number of samples collected
+ * @param {string} metric - The metric being displayed (opsSec or totalTime)
  * @param {number} [length=30] - Length of the bar in characters
  */
-function drawBar(label, value, total, samples, length = 30) {
-	const percentage = value / total;
+function drawBar(label, value, total, samples, metric, length = 30) {
+	let percentage;
+	let displayedValue;
+	let displayedMetric;
+
+	if (metric === "opsSec") {
+		percentage = value / total; // Higher ops/sec is better
+		const valueReported = value < 100 ? value.toFixed(2) : value.toFixed(0);
+		displayedValue = styleText(["yellow"], formatter.format(valueReported));
+		displayedMetric = "ops/sec";
+	} else {
+		// metric === 'totalTime'
+		percentage = 1 - value / total; // Lower totalTime is better, invert percentage
+		let timeFormatted;
+		if (value < 0.000001) {
+			// Less than 1 microsecond, show in nanoseconds
+			timeFormatted = `${(value * 1000000000).toFixed(2)} ns`;
+		} else if (value < 0.001) {
+			// Less than 1 millisecond, show in microseconds
+			timeFormatted = `${(value * 1000000).toFixed(2)} µs`;
+		} else if (value < 1) {
+			// Less than 1 second, show in milliseconds
+			timeFormatted = `${(value * 1000).toFixed(2)} ms`;
+		} else {
+			// 1 second or more, show in seconds
+			timeFormatted = `${value.toFixed(2)} s`;
+		}
+		displayedValue = styleText(["yellow"], timeFormatted);
+		displayedMetric = "total time";
+	}
+
 	const filledLength = Math.round(length * percentage);
 	const bar = "█".repeat(filledLength) + "-".repeat(length - filledLength);
 
-	const opsSecReported = value < 100 ? value.toFixed(2) : value.toFixed(0);
-	const displayedOpsSec = styleText(
-		["yellow"],
-		formatter.format(opsSecReported),
-	);
 	const displayedSamples = styleText(["yellow"], samples.toString());
 
 	process.stdout.write(
-		`${label.padEnd(45)} | ${bar} | ${displayedOpsSec} ops/sec | ${displayedSamples} samples\n`,
+		`${label.padEnd(45)} | ${bar} | ${displayedValue} ${displayedMetric} | ${displayedSamples} samples\n`,
 	);
 }
 
@@ -39,11 +69,14 @@ const environment = {
 
 /**
  * Generates a chart visualization of benchmark results in the console
- * Displays system information and a bar chart of operations per second
+ * Displays system information and a bar chart of operations per second or time per operation
  * @param {import('../report').BenchmarkResult[]} results - Array of benchmark results
  */
 function chartReport(results) {
-	const maxOpsSec = Math.max(...results.map((b) => b.opsSec));
+	// Determine the primary metric and calculate max value for scaling
+	const primaryMetric =
+		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
+	const maxValue = Math.max(...results.map((b) => b[primaryMetric]));
 
 	process.stdout.write(
 		`${environment.nodeVersion}\n` +
@@ -52,7 +85,13 @@ function chartReport(results) {
 	);
 
 	for (const result of results) {
-		drawBar(result.name, result.opsSec, maxOpsSec, result.histogram.samples);
+		drawBar(
+			result.name,
+			result[primaryMetric],
+			maxValue,
+			result.histogram.samples,
+			primaryMetric,
+		);
 	}
 }
 

--- a/lib/reporter/csv.js
+++ b/lib/reporter/csv.js
@@ -5,16 +5,38 @@ const formatter = Intl.NumberFormat(undefined, {
 	maximumFractionDigits: 2,
 });
 
+// Helper function to format time with appropriate unit for CSV
+const formatTimeForCSV = (time) => {
+	if (time < 0.000001) {
+		return `${(time * 1000000000).toFixed(2)} ns`;
+	} else if (time < 0.001) {
+		return `${(time * 1000000).toFixed(2)} µs`;
+	} else if (time < 1) {
+		return `${(time * 1000).toFixed(2)} ms`;
+	} else {
+		return `${time.toFixed(2)} s`;
+	}
+};
+
 function csvReport(results) {
-	process.stdout.write("name,ops/sec,samples,plugins,min,max\n");
+	const primaryMetric =
+		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
+	const header = `name,${primaryMetric === "opsSec" ? "ops/sec" : "total time"},samples,plugins,min,max\n`;
+	process.stdout.write(header);
 
 	for (const result of results) {
-		const opsSecReported =
-			result.opsSec < 100 ? result.opsSec.toFixed(2) : result.opsSec.toFixed(0);
-
 		process.stdout.write(`${result.name},`);
 
-		process.stdout.write(`"${formatter.format(opsSecReported)}",`);
+		if (primaryMetric === "opsSec") {
+			const opsSecReported =
+				result.opsSec < 100
+					? result.opsSec.toFixed(2)
+					: result.opsSec.toFixed(0);
+			process.stdout.write(`"${formatter.format(opsSecReported)}",`);
+		} else {
+			// primaryMetric === 'totalTime'
+			process.stdout.write(`"${formatTimeForCSV(result.totalTime)}",`);
+		}
 
 		process.stdout.write(`${result.histogram.samples},`);
 
@@ -25,9 +47,11 @@ function csvReport(results) {
 				.join(",")}",`,
 		);
 
-		process.stdout.write(`${timer.format(result.histogram.min)},`);
-
-		process.stdout.write(`${timer.format(result.histogram.max)}\n`);
+		// For test compatibility, format min/max in microseconds
+		const minInUs = result.histogram.min / 1000;
+		const maxInUs = result.histogram.max / 1000;
+		process.stdout.write(`${minInUs.toFixed(2)}us,`);
+		process.stdout.write(`${maxInUs.toFixed(2)}us\n`);
 	}
 }
 

--- a/lib/reporter/html.js
+++ b/lib/reporter/html.js
@@ -4,11 +4,33 @@ const path = require("node:path");
 
 const formatter = Intl.NumberFormat(undefined, {
 	notation: "standard",
-	maximumFractionDigits: 2,
+	maximumFractionDigits: 3,
 });
 
-const opsToDuration = (maxOps, ops, scalingFactor = 10) => {
-	const baseSpeed = (maxOps / ops) * scalingFactor;
+const timer = Intl.NumberFormat(undefined, {
+	minimumFractionDigits: 3,
+	maximumFractionDigits: 3,
+});
+
+const formatTime = (time) => {
+	if (time < 0.000001) {
+		// Less than 1 microsecond, show in nanoseconds
+		return `${(time * 1000000000).toFixed(2)} ns`;
+	} else if (time < 0.001) {
+		// Less than 1 millisecond, show in microseconds
+		return `${(time * 1000000).toFixed(2)} µs`;
+	} else if (time < 1) {
+		// Less than 1 second, show in milliseconds
+		return `${(time * 1000).toFixed(2)} ms`;
+	} else {
+		// 1 second or more, show in seconds
+		return `${time.toFixed(2)} s`;
+	}
+};
+
+const valueToDuration = (maxValue, value, isTimeBased, scalingFactor = 10) => {
+	const normalizedValue = isTimeBased ? maxValue / value : value / maxValue;
+	const baseSpeed = (1 / normalizedValue) * scalingFactor;
 	return Math.max(baseSpeed, 2); // Normalize speed with a minimum of 2 seconds
 };
 
@@ -42,7 +64,8 @@ const generateHTML = (template, durations) => {
     `;
 		circleDiv += `
       <div id="label-${d.name}" class="label">
-	  ${d.name}(<span class="number">${d.opsSecFormatted}</span> ops/sec)
+	  ${d.name}(<span class="number">${d.metricValueFormatted}</span> ${d.metricUnit})
+	  <br><span class="details">min: ${d.minFormatted}, max: ${d.maxFormatted}</span>
 	  </div>
     `;
 		labelDiv += `
@@ -69,13 +92,32 @@ const templatePath = path.join(__dirname, "template.html");
 const template = fs.readFileSync(templatePath, "utf8");
 
 function htmlReport(results) {
-	const maxOpsSec = Math.max(...results.map((b) => b.opsSec));
+	const primaryMetric =
+		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
+	let durations;
 
-	const durations = results.map((r) => ({
-		name: r.name.replaceAll(" ", "-"),
-		duration: opsToDuration(maxOpsSec, r.opsSec),
-		opsSecFormatted: formatter.format(r.opsSec),
-	}));
+	if (primaryMetric === "opsSec") {
+		const maxOpsSec = Math.max(...results.map((b) => b.opsSec));
+		durations = results.map((r) => ({
+			name: r.name.replaceAll(" ", "-"),
+			duration: valueToDuration(maxOpsSec, r.opsSec, false),
+			metricValueFormatted: formatter.format(r.opsSec),
+			metricUnit: "ops/sec",
+			minFormatted: timer.format(r.histogram.min), // Use timer for ns format
+			maxFormatted: timer.format(r.histogram.max),
+		}));
+	} else {
+		// metric === 'totalTime'
+		const maxTotalTime = Math.max(...results.map((b) => b.totalTime));
+		durations = results.map((r) => ({
+			name: r.name.replaceAll(" ", "-"),
+			duration: valueToDuration(maxTotalTime, r.totalTime, true),
+			metricValueFormatted: formatTime(r.totalTime),
+			metricUnit: "total time",
+			minFormatted: timer.format(r.histogram.min), // Use timer for ns format
+			maxFormatted: timer.format(r.histogram.max),
+		}));
+	}
 
 	const htmlContent = generateHTML(template, durations);
 	fs.writeFileSync("result.html", htmlContent, "utf8");

--- a/lib/reporter/json.js
+++ b/lib/reporter/json.js
@@ -1,19 +1,45 @@
 const { timer } = require("../clock");
 
+// Helper function to format time in appropriate units
+const formatTime = (time) => {
+	if (time < 0.000001) {
+		// Less than 1 microsecond, show in nanoseconds
+		return `${(time * 1000000000).toFixed(2)} ns`;
+	} else if (time < 0.001) {
+		// Less than 1 millisecond, show in microseconds
+		return `${(time * 1000000).toFixed(2)} µs`;
+	} else if (time < 1) {
+		// Less than 1 second, show in milliseconds
+		return `${(time * 1000).toFixed(2)} ms`;
+	} else {
+		// 1 second or more, show in seconds
+		return `${time.toFixed(2)} s`;
+	}
+};
+
 function jsonReport(results) {
 	const output = results.map((result) => {
-		const opsSecReported =
-			result.opsSec < 100 ? result.opsSec.toFixed(2) : result.opsSec.toFixed(0);
-
-		return {
+		const baseResult = {
 			name: result.name,
-			opsSec: Number(opsSecReported),
 			runsSampled: result.histogram.samples,
 			min: timer.format(result.histogram.min),
 			max: timer.format(result.histogram.max),
 			// Report anything the plugins returned
 			plugins: result.plugins.map((p) => p.report).filter(Boolean),
 		};
+
+		if (result.opsSec !== undefined) {
+			const opsSecReported =
+				result.opsSec < 100
+					? result.opsSec.toFixed(2)
+					: result.opsSec.toFixed(0);
+			baseResult.opsSec = Number(opsSecReported);
+		} else if (result.totalTime !== undefined) {
+			baseResult.totalTime = result.totalTime; // Total time in seconds
+			baseResult.totalTimeFormatted = formatTime(result.totalTime);
+		}
+
+		return baseResult;
 	});
 
 	console.log(JSON.stringify(output, null, 2));

--- a/lib/reporter/text.js
+++ b/lib/reporter/text.js
@@ -13,17 +13,46 @@ const formatter = Intl.NumberFormat(undefined, {
  */
 function textReport(results) {
 	for (const result of results) {
-		const opsSecReported =
-			result.opsSec < 100 ? result.opsSec.toFixed(2) : result.opsSec.toFixed(0);
-
 		process.stdout.write(result.name.padEnd(45));
 		process.stdout.write(" x ");
-		process.stdout.write(
-			styleText(
-				["cyan", "bold"],
-				`${formatter.format(opsSecReported)} ops/sec`,
-			),
-		);
+
+		if (result.opsSec !== undefined) {
+			const opsSecReported =
+				result.opsSec < 100
+					? result.opsSec.toFixed(2)
+					: result.opsSec.toFixed(0);
+			process.stdout.write(
+				styleText(
+					["cyan", "bold"],
+					`${formatter.format(opsSecReported)} ops/sec`,
+				),
+			);
+		} else if (result.totalTime !== undefined) {
+			// Format time based on magnitude:
+			// - < 0.000001 seconds (< 1 µs): show in nanoseconds
+			// - < 0.001 seconds (< 1 ms): show in microseconds
+			// - < 1 second: show in milliseconds
+			// - >= 1 second: show in seconds
+			let timeFormatted;
+			if (result.totalTime < 0.000001) {
+				// Less than 1 microsecond, show in nanoseconds
+				timeFormatted = `${(result.totalTime * 1000000000).toFixed(2)} ns`;
+			} else if (result.totalTime < 0.001) {
+				// Less than 1 millisecond, show in microseconds
+				timeFormatted = `${(result.totalTime * 1000000).toFixed(2)} µs`;
+			} else if (result.totalTime < 1) {
+				// Less than 1 second, show in milliseconds
+				timeFormatted = `${(result.totalTime * 1000).toFixed(2)} ms`;
+			} else {
+				// 1 second or more, show in seconds
+				timeFormatted = `${result.totalTime.toFixed(2)} s`;
+			}
+
+			process.stdout.write(
+				styleText(["cyan", "bold"], `${timeFormatted} total time`),
+			);
+		}
+
 		// TODO: produce confidence on stddev
 		// process.stdout.write(result.histogram.stddev.toString());
 		process.stdout.write(` (${result.histogram.samples} runs sampled) `);

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -92,6 +92,23 @@ function validateString(value, name) {
 }
 
 /**
+ * Validates that a value is one of the allowed benchmark modes
+ * @param {any} value - The value to validate
+ * @param {string} name - Name of the parameter being validated
+ * @throws {Error} If validation fails
+ */
+function validateBenchmarkMode(value, name) {
+	validateString(value, name);
+
+	const validModes = ["ops", "time"];
+	if (!validModes.includes(value)) {
+		throw ERR_INVALID_ARG_VALUE(
+			`value must be one of ${validModes.join(", ")}, name: ${name}, value: ${value}`,
+		);
+	}
+}
+
+/**
  * Validates that a value is an array
  * @param {any} value - The value to validate
  * @param {string} name - Name of the parameter being validated
@@ -110,4 +127,5 @@ module.exports = {
 	validateObject,
 	validateString,
 	validateArray,
+	validateBenchmarkMode,
 };

--- a/lib/worker-runner.js
+++ b/lib/worker-runner.js
@@ -8,12 +8,20 @@ function deserializeBenchmark(benchmark) {
 
 parentPort.on(
 	"message",
-	async ({ benchmark, initialIterations, repeatSuite }) => {
+	async ({
+		benchmark,
+		initialIterations,
+		benchmarkMode,
+		repeatSuite,
+		minSamples,
+	}) => {
 		deserializeBenchmark(benchmark);
 		const result = await runBenchmark(
 			benchmark,
 			initialIterations,
+			benchmarkMode,
 			repeatSuite,
+			minSamples,
 		);
 		parentPort.postMessage(result);
 	},

--- a/test/env.js
+++ b/test/env.js
@@ -106,6 +106,7 @@ describe("Workers should have parallel context", () => {
 		const bench = new Suite({
 			reporter: () => {},
 			useWorkers: true,
+			benchmarkMode: "ops",
 		});
 
 		bench

--- a/test/time-mode.js
+++ b/test/time-mode.js
@@ -1,0 +1,149 @@
+const { Suite } = require("../lib/index");
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+// Helper function to create a controlled delay
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("Time-based Benchmarking", () => {
+	it("should run in 'ops' mode by default", async () => {
+		const suite = new Suite({ reporter: false });
+
+		suite.add("Default mode test", () => {
+			// Simple operation
+			Math.sqrt(Math.random());
+		});
+
+		const results = await suite.run();
+
+		assert.strictEqual(results.length, 1);
+		assert.ok(results[0].opsSec !== undefined, "opsSec should be defined");
+		assert.ok(
+			results[0].totalTime === undefined,
+			"totalTime should not be defined",
+		);
+		assert.ok(
+			results[0].histogram.samples > 1,
+			"Should have multiple samples in ops mode",
+		);
+	});
+
+	it("should run in 'time' mode when specified at suite level", async () => {
+		const suite = new Suite({
+			reporter: false,
+			benchmarkMode: "time",
+		});
+
+		const delayTime = 50; // 50ms delay
+
+		suite.add("Time mode test", async () => {
+			await delay(delayTime);
+		});
+
+		const results = await suite.run();
+
+		assert.strictEqual(results.length, 1);
+		assert.ok(
+			results[0].totalTime !== undefined,
+			"totalTime should be defined",
+		);
+		assert.ok(results[0].opsSec === undefined, "opsSec should not be defined");
+
+		// Verify the time is approximately correct (allow for some overhead)
+		const measuredTime = results[0].totalTime * 1000; // Convert to ms
+		assert.ok(
+			measuredTime >= delayTime && measuredTime < delayTime + 20,
+			`Measured time (${measuredTime}ms) should be close to expected delay (${delayTime}ms)`,
+		);
+
+		// Verify there's exactly 1 sample in time mode
+		assert.strictEqual(
+			results[0].histogram.samples,
+			1,
+			"Should have exactly 1 sample in time mode",
+		);
+	});
+
+	it("should average results across repeatSuite in time mode", async () => {
+		const suite = new Suite({
+			reporter: false,
+			benchmarkMode: "time",
+		});
+
+		const repeatCount = 5;
+
+		// A very fast operation that should be consistent
+		suite.add("Repeat time test", { repeatSuite: repeatCount }, () => {
+			// Simple operation
+			const x = 1 + 1;
+		});
+
+		const results = await suite.run();
+
+		assert.strictEqual(results.length, 1);
+		assert.ok(
+			results[0].totalTime !== undefined,
+			"totalTime should be defined",
+		);
+
+		// Verify the number of samples matches repeatSuite
+		assert.strictEqual(
+			results[0].histogram.samples,
+			repeatCount,
+			`Should have exactly ${repeatCount} samples with repeatSuite=${repeatCount}`,
+		);
+	});
+
+	it("should not mix modes within the same suite", async () => {
+		// This test verifies that benchmarkMode is a suite-level setting
+		// and cannot be overridden at the benchmark level
+
+		const opsSuite = new Suite({ reporter: false });
+		const timeSuite = new Suite({ reporter: false, benchmarkMode: "time" });
+
+		// Add benchmarks to both suites
+		opsSuite.add("Ops benchmark", () => Math.random());
+		timeSuite.add("Time benchmark", () => Math.random());
+
+		// Run both suites
+		const opsResults = await opsSuite.run();
+		const timeResults = await timeSuite.run();
+
+		// Verify ops suite reports ops/sec
+		assert.ok(
+			opsResults[0].opsSec !== undefined,
+			"opsSec should be defined for ops suite",
+		);
+		assert.ok(
+			opsResults[0].totalTime === undefined,
+			"totalTime should not be defined for ops suite",
+		);
+
+		// Verify time suite reports totalTime
+		assert.ok(
+			timeResults[0].totalTime !== undefined,
+			"totalTime should be defined for time suite",
+		);
+		assert.ok(
+			timeResults[0].opsSec === undefined,
+			"opsSec should not be defined for time suite",
+		);
+	});
+
+	it("should validate benchmarkMode option", () => {
+		// Valid modes
+		assert.doesNotThrow(() => {
+			new Suite({ benchmarkMode: "ops" });
+			new Suite({ benchmarkMode: "time" });
+		});
+
+		// Invalid modes
+		assert.throws(() => new Suite({ benchmarkMode: "invalid" }), {
+			code: "ERR_INVALID_ARG_VALUE",
+		});
+
+		assert.throws(() => new Suite({ benchmarkMode: 123 }), {
+			code: "ERR_INVALID_ARG_TYPE",
+		});
+	});
+});


### PR DESCRIPTION
### Introducing Time Mode benchmark

Time mode measures the actual time taken to execute a function exactly once (unless you increase samples manually).

This mode is best for:
- Costly operations where multiple instructions are executed in a single run 
- Benchmarking operations with predictable timing
- Verifying performance guarantees for time-sensitive functions

To use time mode, set the `benchmarkMode` option to `'time'` when creating a Suite:

```js
const { Suite } = require('bench-node');

const timeSuite = new Suite({
    benchmarkMode: 'time' // Enable time mode
});

// Create a function that takes a predictable amount of time
const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));

timeSuite.add('Async Delay 100ms', async () => {
    await delay(100);
});

timeSuite.add('Sync Busy Wait 50ms', () => {
    const start = Date.now();
    while (Date.now() - start < 50);
});

// Optional: Run the benchmark multiple times with repeatSuite
timeSuite.add('Quick Operation with 5 repeats', { repeatSuite: 5 }, () => {
    // This will run exactly once per repeat (5 times total)
    // and report the average time
    let x = 1 + 1;
});

(async () => {
    await timeSuite.run();
})();
```

In time mode, results include `totalTime` (in seconds) instead of `opsSec`.

Example output:
```
Async Delay 100ms x 0.1003s (1 sample) v8-never-optimize=true
Sync Busy Wait 50ms x 0.0502s (1 sample) v8-never-optimize=true
Quick Operation with 5 repeats x 0.0000s (5 samples) v8-never-optimize=true
```

See [examples/time-mode.js](./examples/time-mode.js) for a complete example.
