### PR TITLE
feat: add pretty-reporter and shorthand pretty: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,55 @@ const suite = new Suite({
 });
 ```
 
+### Pretty Reporter
+
+The `prettyReport` provides a beautiful, hierarchical view of your benchmark results.
+
+**Usage:**
+
+```javascript
+const { Suite } = require('bench-node');
+
+// You can either pass the reporter function directly...
+const suiteWithReporter = new Suite({
+  reporter: prettyReport,
+});
+
+// ...or use the `pretty` option for convenience.
+const suiteWithPrettyOption = new Suite({
+  pretty: true,
+});
+
+suite
+  .add('my-group/my-benchmark', () => {
+    //...
+  })
+  .add('my-group/my-benchmark-2', () => {
+    //...
+  })
+  .add('second-group/baseline', () => {
+    //...
+  })
+  .run();
+```
+
+**Sample Output:**
+
+```
+System Information:
+  Node.js: v22.15.0
+  OS: darwin 24.5.0
+  CPU: Apple M2
+
+Benchmark results (3 total):
+Plugins enabled: V8NeverOptimizePlugin
+├─ my-group
+│ ├─ my-benchmark                                      1,461,380 ops/sec (10 runs sampled) min..max=(682.30ns...685.79ns)
+│ └─ my-benchmark-2                                    2,270,973 ops/sec (10 runs sampled) min..max=(437.22ns...444.12ns)
+└─ second-group
+  └─ baseline                                          637,787 ops/sec (11 runs sampled) min..max=(1.54us...1.59us)
+```
+
 ### Custom Reporter
 
 Customize data reporting by providing a `reporter` function when creating the `Suite`:

--- a/examples/pretty-report/node.js
+++ b/examples/pretty-report/node.js
@@ -1,19 +1,24 @@
-const { Suite, csvReport } = require('../../lib');
+const { Suite, prettyReport } = require('../../lib');
 const assert = require('node:assert');
 
 const suite = new Suite({
-  reporter: csvReport,
+  reporter: prettyReport,
 });
 
 suite
-  .add('single with matcher', function () {
+  .add('my-group/my-benchmark', () => {
     const pattern = /[123]/g
     const replacements = { 1: 'a', 2: 'b', 3: 'c' }
-    const subject = '123123123123123123123123123123123123123123123123'
+    const subject = '12312312312312312312312'
     const r = subject.replace(pattern, m => replacements[m])
     assert.ok(r);
   })
-  .add('multiple replaces', function () {
+  .add('my-group/my-benchmark-2', function () {
+    const subject = '123123123123'
+    const r = subject.replace(/1/g, 'a').replace(/2/g, 'b').replace(/3/g, 'c')
+    assert.ok(r);
+  })
+  .add('second-group/baseline', function () {
     const subject = '123123123123123123123123123123123123123123123123'
     const r = subject.replace(/1/g, 'a').replace(/2/g, 'b').replace(/3/g, 'c')
     assert.ok(r);

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const {
 	htmlReport,
 	jsonReport,
 	csvReport,
+	prettyReport,
 } = require("./report");
 const {
 	getInitialIterations,
@@ -106,6 +107,8 @@ class Suite {
 				validateFunction(options.reporter, "reporter");
 			}
 			this.#reporter = options.reporter;
+		} else if (options?.pretty === true) {
+			this.#reporter = prettyReport;
 		} else {
 			this.#reporter = textReport;
 		}
@@ -259,6 +262,7 @@ module.exports = {
 	V8OptimizeOnNextCallPlugin,
 	chartReport,
 	textReport,
+	prettyReport,
 	htmlReport,
 	jsonReport,
 	csvReport,

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,4 +1,5 @@
 const { textReport } = require("./reporter/text");
+const { prettyReport } = require("./reporter/pretty");
 const { chartReport } = require("./reporter/chart");
 const { htmlReport } = require("./reporter/html");
 const { jsonReport } = require("./reporter/json");
@@ -25,6 +26,7 @@ const { csvReport } = require("./reporter/csv");
 module.exports = {
 	chartReport,
 	textReport,
+	prettyReport,
 	htmlReport,
 	jsonReport,
 	csvReport,

--- a/lib/reporter/pretty.js
+++ b/lib/reporter/pretty.js
@@ -1,0 +1,148 @@
+const { styleText } = require("../utils/styleText");
+const { timer } = require("../clock");
+const os = require("node:os");
+
+const formatter = Intl.NumberFormat(undefined, {
+	notation: "standard",
+	maximumFractionDigits: 2,
+});
+
+const BOX_VERTICAL = "│";
+const BOX_HORIZONTAL = "─";
+const BOX_CORNER_BOTTOM_LEFT = "└";
+const BOX_TEE_RIGHT = "├";
+
+/**
+ * @param {import('../report').BenchmarkResult[]} results
+ */
+function prettyReport(results) {
+	if (results.length === 0) {
+		return;
+	}
+
+	const cpu = os.cpus()[0];
+	process.stdout.write(styleText("bold", "\nSystem Information:\n"));
+	process.stdout.write(`  Node.js: ${process.version}\n`);
+	process.stdout.write(`  OS: ${os.platform()} ${os.release()}\n`);
+	process.stdout.write(`  CPU: ${cpu.model}\n`);
+
+	process.stdout.write(
+		styleText("bold", `\nBenchmark results (${results.length} total):\n`),
+	);
+
+	const firstResult = results[0];
+	if (firstResult && firstResult.plugins.length > 0) {
+		const pluginNames = firstResult.plugins.map((p) => p.name).join(", ");
+		process.stdout.write(styleText("dim", `Plugins enabled: ${pluginNames}\n`));
+	}
+
+	const tree = buildTree(results);
+	printTree(tree);
+	process.stdout.write("\n");
+}
+
+function buildTree(results) {
+	const tree = { children: new Map() };
+
+	for (const result of results) {
+		const parts = result.name.split("/");
+		let currentNode = tree;
+
+		for (let i = 0; i < parts.length; i++) {
+			const part = parts[i];
+			if (!currentNode.children.has(part)) {
+				currentNode.children.set(part, { children: new Map() });
+			}
+			currentNode = currentNode.children.get(part);
+
+			if (i === parts.length - 1) {
+				currentNode.result = result;
+			}
+		}
+	}
+
+	return tree;
+}
+
+function printTree(node, prefix = "", isLast = true) {
+	const children = Array.from(node.children.entries());
+	for (let i = 0; i < children.length; i++) {
+		const [name, childNode] = children[i];
+		const isCurrentLast = i === children.length - 1;
+		const connector = isCurrentLast
+			? `${BOX_CORNER_BOTTOM_LEFT}${BOX_HORIZONTAL}`
+			: `${BOX_TEE_RIGHT}${BOX_HORIZONTAL}`;
+
+		const prefixStyled = styleText("dim", `${prefix}${connector}`);
+
+		if (childNode.result) {
+			const nameStyled = ` ${styleText(["bold"], name)}`;
+			process.stdout.write(prefixStyled);
+			process.stdout.write(nameStyled);
+			const prefixUnstyled = `${prefix}${connector}`;
+			const nameUnstyled = ` ${name}`;
+			const unstyledLength = prefixUnstyled.length + nameUnstyled.length;
+			printResult(childNode.result, unstyledLength);
+		} else {
+			// This is a group
+			const nameStyled = ` ${styleText(["bold", "yellow"], name)}`;
+			process.stdout.write(prefixStyled);
+			process.stdout.write(nameStyled);
+		}
+
+		process.stdout.write("\n");
+
+		const newPrefix = `${prefix}${isCurrentLast ? "  " : `${BOX_VERTICAL} `}`;
+		if (childNode.children.size > 0) {
+			printTree(childNode, newPrefix, isCurrentLast);
+		}
+	}
+}
+
+function printResult(result, prefixLength) {
+	const PADDING = 55;
+	const padding = PADDING - prefixLength > 0 ? PADDING - prefixLength : 0;
+	process.stdout.write(" ".repeat(padding));
+
+	const color = "cyan";
+
+	if (result.opsSec !== undefined) {
+		const opsSecReported =
+			result.opsSec < 100 ? result.opsSec.toFixed(2) : result.opsSec.toFixed(0);
+		process.stdout.write(
+			styleText([color, "bold"], `${formatter.format(opsSecReported)} ops/sec`),
+		);
+	} else if (result.totalTime !== undefined) {
+		let timeFormatted;
+		if (result.totalTime < 0.000001) {
+			timeFormatted = `${(result.totalTime * 1000000000).toFixed(2)} ns`;
+		} else if (result.totalTime < 0.001) {
+			timeFormatted = `${(result.totalTime * 1000000).toFixed(2)} µs`;
+		} else if (result.totalTime < 1) {
+			timeFormatted = `${(result.totalTime * 1000).toFixed(2)} ms`;
+		} else {
+			timeFormatted = `${result.totalTime.toFixed(2)} s`;
+		}
+		process.stdout.write(
+			styleText([color, "bold"], `${timeFormatted} total time`),
+		);
+	}
+
+	const samples = result.samples || result.histogram?.samples;
+	process.stdout.write(` (${samples} runs sampled) `);
+
+	if (result.histogram) {
+		process.stdout.write("min..max=(");
+		process.stdout.write(
+			styleText("green", timer.format(result.histogram.min)),
+		);
+		process.stdout.write(styleText("dim", "..."));
+		process.stdout.write(
+			styleText("red", `${timer.format(result.histogram.max)})`),
+		);
+	}
+}
+
+module.exports = {
+	prettyReport,
+};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4099dd0-67b5-4a61-bad6-5659668a07f8)

This will be the default text report on v1.0.0 of bench-node. For now, let's use it through a flag `pretty: true` or using `prettyReporter`