### PR TITLE
Allow looping over multiple results to issue a single report.

### DIFF
--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -73,16 +73,27 @@ const environment = {
  * @param {import('../report').BenchmarkResult[]} results - Array of benchmark results
  */
 function chartReport(results) {
-	// Determine the primary metric and calculate max value for scaling
-	const primaryMetric =
-		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
-	const maxValue = Math.max(...results.map((b) => b[primaryMetric]));
-
 	process.stdout.write(
 		`${environment.nodeVersion}\n` +
 			`Platform: ${environment.platform}\n` +
 			`CPU Cores: ${environment.hardware}\n\n`,
 	);
+
+	if (results.length === 0 || !Array.isArray(results[0])) {
+		showChart(results);
+	} else {
+		for (const entry of results) {
+			showChart(entry);
+			process.stdout.write("\n");
+		}
+	}
+}
+
+function showChart(results) {
+	// Determine the primary metric and calculate max value for scaling
+	const primaryMetric =
+		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
+	const maxValue = Math.max(...results.map((b) => b[primaryMetric]));
 
 	for (const result of results) {
 		drawBar(


### PR DESCRIPTION
I need to be able to run dozens of individual benchmarks in a single run and then summarize them at the end, after the dust has settled. The best option appears to be the chart report, however it assumes it's running a single benchmark and thus prints out a header, which is not helpful for a summary view.

This PR allows the chart function to accept an array of arrays, and print out each set of reports separately, but with only one
header between them.

helps with #88