### PR TITLE
Disable headers for the chart code

### DIFF
--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -78,11 +78,13 @@ function chartReport(results) {
 		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
 	const maxValue = Math.max(...results.map((b) => b[primaryMetric]));
 
-	process.stdout.write(
-		`${environment.nodeVersion}\n` +
-			`Platform: ${environment.platform}\n` +
-			`CPU Cores: ${environment.hardware}\n\n`,
-	);
+  if (header) {
+		process.stdout.write(
+				`${environment.nodeVersion}\n` +
+				`Platform: ${environment.platform}\n` +
+				`CPU Cores: ${environment.hardware}\n\n`,
+		);
+	}
 
 	for (const result of results) {
 		drawBar(


### PR DESCRIPTION
Alternative solution to the problem I mention in #88 

All I really need is one header for multiple reports. If you prefer this solution, then you can ignore the other PR