### PR TITLE
Text color on light terminals

### DIFF
--- a/lib/reporter/pretty.js
+++ b/lib/reporter/pretty.js
@@ -156,7 +156,7 @@ function printResult(result, prefixLength) {
 	const padding = PADDING - prefixLength > 0 ? PADDING - prefixLength : 0;
 	process.stdout.write(" ".repeat(padding));
 
-	const color = "cyan";
+	const color = "blue";
 
 	if (result.opsSec !== undefined) {
 		const opsSecReported =

--- a/lib/reporter/text.js
+++ b/lib/reporter/text.js
@@ -23,7 +23,7 @@ function textReport(results) {
 					: result.opsSec.toFixed(0);
 			process.stdout.write(
 				styleText(
-					["cyan", "bold"],
+					["blue", "bold"],
 					`${formatter.format(opsSecReported)} ops/sec`,
 				),
 			);
@@ -49,7 +49,7 @@ function textReport(results) {
 			}
 
 			process.stdout.write(
-				styleText(["cyan", "bold"], `${timeFormatted} total time`),
+				styleText(["blue", "bold"], `${timeFormatted} total time`),
 			);
 		}
 


### PR DESCRIPTION
I'm having some trouble scanning the results on my light terminal.

Looks fine in my IDE (dark) but Terminal is a tough read with cyan on white. Blue on white is much easier, and still looks good on dark.

I think a light/dark version could be a good thing, but I'm not familiar enough with your code yet to pull that off. 