### PR TITLE
feat: Show bar chart with 2% resolution by using partial width box characters

### DIFF
--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -1,16 +1,6 @@
 const { platform, arch, cpus, totalmem } = require("node:os");
 const { styleText } = require("../utils/styleText");
 
-const formatter = Intl.NumberFormat(undefined, {
-	notation: "standard",
-	maximumFractionDigits: 2,
-});
-
-const timer = Intl.NumberFormat(undefined, {
-	minimumFractionDigits: 3,
-	maximumFractionDigits: 3,
-});
-
 /**
  * Draws a bar chart representation of a benchmark result
  * @param {string} label - The label for the bar (benchmark name)
@@ -18,9 +8,9 @@ const timer = Intl.NumberFormat(undefined, {
  * @param {number} total - The maximum value in the dataset (for scaling)
  * @param {number} samples - Number of samples collected
  * @param {string} metric - The metric being displayed (opsSec or totalTime)
- * @param {number} [length=30] - Length of the bar in characters
+ * @param {number} [length=25] - Length of the bar in characters
  */
-function drawBar(label, value, total, samples, metric, length = 30) {
+function drawBar(label, value, total, samples, metric, length = 25) {
 	let percentage;
 	let displayedValue;
 	let displayedMetric;
@@ -51,8 +41,20 @@ function drawBar(label, value, total, samples, metric, length = 30) {
 		displayedMetric = "total time";
 	}
 
-	const filledLength = Math.round(length * percentage);
-	const bar = "█".repeat(filledLength) + "-".repeat(length - filledLength);
+	const ratio = length * percentage;
+	const filledLength = Math.floor(ratio);
+	const fraction = ratio % 1;
+
+	let partial = "";
+
+	if (fraction >= 0.5) {
+		partial = "▌";
+	}
+
+	const bar =
+		"█".repeat(filledLength) +
+		partial +
+		"─".repeat(length - filledLength - partial.length);
 
 	const displayedSamples = styleText(["yellow"], samples.toString());
 
@@ -60,6 +62,16 @@ function drawBar(label, value, total, samples, metric, length = 30) {
 		`${label.padEnd(45)} | ${bar} | ${displayedValue} ${displayedMetric} | ${displayedSamples} samples\n`,
 	);
 }
+
+const formatter = Intl.NumberFormat(undefined, {
+	notation: "standard",
+	maximumFractionDigits: 2,
+});
+
+const timer = Intl.NumberFormat(undefined, {
+	minimumFractionDigits: 3,
+	maximumFractionDigits: 3,
+});
 
 const environment = {
 	nodeVersion: `Node.js version: ${process.version}`,


### PR DESCRIPTION
Half-width characters give 2% resolution on a 25 character-wide bar.

example:
```

constructors ⇒ new Registry()
 ⇒ prom-client@latest                         | █████████████████████████ | 15,259,633 ops/sec | 11 samples
 ⇒ prom-client@trunk                          | ██████████████████████▌── | 14,016,409 ops/sec | 11 samples
 ⇒ prom-client@current                        | ██████████████████████▌── | 13,889,989 ops/sec | 11 samples

constructors ⇒ new Counter()
 ⇒ prom-client@latest                         | █████████████████████──── | 1,081,591 ops/sec | 11 samples
 ⇒ prom-client@trunk                          | █████████████████████████ | 1,281,427 ops/sec | 10 samples
 ⇒ prom-client@current                        | ████████████████████████▌ | 1,272,858 ops/sec | 10 samples
```

I attempted to do this as 1/4 width, but only the half-width character pastes properly in Chrome and Firefox. Anything finer than than looks weird in browsers, as you can see here:

https://en.wikipedia.org/wiki/Box-drawing_characters - only 'C' is the same height as '8'.