### PR TITLE
Configurable column width for text and chart formatting.

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,11 @@
 		"enabled": true
 	},
 	"files": {
-		"ignore": ["examples/*", "test/plugin-api-doc.js", "package.json"]
+		"ignore": [
+			"examples/*",
+			"coverage/*",
+			"test/plugin-api-doc.js",
+			"package.json"
+		]
 	}
 }

--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -67,7 +67,7 @@ function drawBar(
 		"─".repeat(length - filledLength - partial.length);
 
 	const displayedSamples = `${styleText(["yellow"], samples.toString().padStart(2))} samples`;
-	const line = `${label.padEnd(45)} | ${bar} | ${displayedValue} ${displayedMetric} | ${displayedSamples} ${comment}\n`;
+	const line = `${label} | ${bar} | ${displayedValue} ${displayedMetric} | ${displayedSamples} ${comment}\n`;
 
 	process.stdout.write(line);
 }
@@ -92,14 +92,15 @@ const environment = {
  * Generates a chart visualization of benchmark results in the console
  * Displays system information and a bar chart of operations per second or time per operation
  * @param {import('../report').BenchmarkResult[]} results - Array of benchmark results
+ * @param options {object} layout options
  */
-function chartReport(results, options) {
+function chartReport(results, options = {}) {
 	// Determine the primary metric and calculate max value for scaling
 	const primaryMetric =
 		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
 	const maxValue = Math.max(...results.map((b) => b[primaryMetric]));
 
-	if (options?.printHeader) {
+	if (options.printHeader) {
 		process.stdout.write(
 			`${environment.nodeVersion}\n` +
 				`Platform: ${environment.platform}\n` +
@@ -128,8 +129,10 @@ function chartReport(results, options) {
 			}
 		}
 
+		const columnWidth = options.labelWidth ?? 45;
+
 		drawBar(
-			result.name,
+			result.name.padEnd(columnWidth),
 			result[primaryMetric],
 			maxValue,
 			result.histogram.samples,

--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -94,7 +94,7 @@ const environment = {
  * @param {import('../report').BenchmarkResult[]} results - Array of benchmark results
  * @param options {object} layout options
  */
-function chartReport(results, options = {}) {
+function chartReport(results, options = { labelWidth: 45, printHeader: true }) {
 	// Determine the primary metric and calculate max value for scaling
 	const primaryMetric =
 		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";

--- a/lib/reporter/pretty.js
+++ b/lib/reporter/pretty.js
@@ -54,11 +54,8 @@ function prettyReport(results) {
 		const maxNameLength = Math.max(...sortedResults.map((r) => r.name.length));
 
 		for (const result of sortedResults) {
-			const namePart = `  ${result.name}`;
+			const namePart = `  ${result.name.padEnd(maxNameLength)}  `;
 			process.stdout.write(namePart);
-
-			const padding = maxNameLength - result.name.length + 2;
-			process.stdout.write(" ".repeat(padding));
 
 			if (result.baseline) {
 				process.stdout.write(styleText("magenta", "(baseline)"));

--- a/lib/reporter/text.js
+++ b/lib/reporter/text.js
@@ -11,10 +11,11 @@ const formatter = Intl.NumberFormat(undefined, {
  * Generates a text report of benchmark results, displaying each benchmark's name,
  * operations per second, number of samples, plugin results, and min/max timings
  * @param {import('../report').BenchmarkResult[]} results - Array of benchmark results
+ * @param options {object} layout options
  */
-function textReport(results) {
+function textReport(results, options = {}) {
 	for (const result of results) {
-		process.stdout.write(result.name.padEnd(45));
+		process.stdout.write(result.name.padEnd(options.labelWidth ?? 45));
 		process.stdout.write(" x ");
 
 		if (result.opsSec !== undefined) {

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -430,7 +430,7 @@ describe("baseline comparisons", async (t) => {
 				output += data;
 			};
 
-			chartReport(results);
+			chartReport(results, { labelWidth: 30 });
 			process.stdout.write = originalStdoutWrite;
 		});
 
@@ -446,6 +446,11 @@ describe("baseline comparisons", async (t) => {
 		it("should show 'slower' comparison in summary", () => {
 			const summary = output.split("Summary (vs. baseline):")[1];
 			assert.ok(summary.includes("slower"));
+		});
+
+		it("can set a specific column width", () => {
+			const summary = output.split("Summary (vs. baseline):")[1];
+			assert.ok(summary.includes("baseline-test                  |"));
 		});
 	});
 });


### PR DESCRIPTION
I'd like narrower chart output for my use case, since my labels tend to be much shorter than 45 columns. 

Also fixes a problem with the linter complaining about coverage/* 