### PR TITLE
feat: reduce NPM package size by adding files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
 	},
 	"c8": {
 		"reporter": "lcov"
-	}
+	},
+	"files": [
+		"lib/",
+		"index.d.ts"
+	]
 }


### PR DESCRIPTION
## Description
This PR significantly reduces the NPM package size by adding a `files` field to package.json.

## Changes
- Added 'files' field to package.json specifying only `lib/` and `index.d.ts`
- Package size reduced from ~1MB to ~25KB

## What's excluded
- examples/ folder
- test/ folder  
- config files (biome.json, etc.)
- documentation files (except README.md which is auto-included)

## Testing
Verified with `npm pack --dry-run` that only essential files are included.

Fixes the issue mentioned in https://www.npmjs.com/package/bench-node?activeTab=code