### PR TITLE
exported types: add prettyReport, Timer.end()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export declare namespace BenchNode {
 
 	type BenchmarkFunction = (timer?: {
 		start: () => void;
+		end: (iterations?: number) => void;
 		count: number;
 	}) => void | Promise<void>;
 
@@ -80,6 +81,7 @@ export declare namespace BenchNode {
 
 export declare const textReport: BenchNode.ReporterFunction;
 export declare const chartReport: BenchNode.ReporterFunction;
+export declare const prettyReport: BenchNode.ReporterFunction;
 export declare const htmlReport: BenchNode.ReporterFunction;
 export declare const jsonReport: BenchNode.ReporterFunction;
 export declare const csvReport: BenchNode.ReporterFunction;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -10,6 +10,7 @@ import {
 	csvReport,
 	htmlReport,
 	jsonReport,
+	prettyReport,
 	textReport,
 } from "..";
 
@@ -72,6 +73,7 @@ expectType<BenchNode.Suite>(
 const managedBenchFn: BenchNode.BenchmarkFunction = (timer) => {
 	if (timer) {
 		expectType<() => void>(timer.start);
+		expectType<(iterations?: number) => void>(timer.end);
 		expectType<number>(timer.count);
 		timer.start();
 		for (let i = 0; i < timer.count; i++) {
@@ -121,6 +123,7 @@ expectType<void>(chartReport(sampleResults));
 expectType<void>(htmlReport(sampleResults));
 expectType<void>(jsonReport(sampleResults));
 expectType<void>(csvReport(sampleResults));
+expectType<void>(prettyReport(sampleResults));
 
 // Test Plugins
 const plugin1 = new V8NeverOptimizePlugin();


### PR DESCRIPTION
Thanks for all the great work on this project! I noticed a couple of small issues when using this in a typescript project:

- The example code says to call `timer.start()` and `timer.end(timer.count)`, but the signature for `BenchmarkFunction` didn't include an `end` method.
- `prettyReport` exists in `lib/index.js`, but wouldn't successfully import to a typescript project since it wasn't in `index.d.ts`

Just wanted to quickly capture this fix when I bumped into it, but please let me know if there's a better way to submit this!