### PR TITLE
Deduplicate the data summarization code in the reporters

### DIFF
--- a/lib/reporter/csv.js
+++ b/lib/reporter/csv.js
@@ -1,22 +1,9 @@
-const { timer } = require("../clock");
+const { summarize } = require("../utils/analyze");
 
 const formatter = Intl.NumberFormat(undefined, {
 	notation: "standard",
 	maximumFractionDigits: 2,
 });
-
-// Helper function to format time with appropriate unit for CSV
-const formatTimeForCSV = (time) => {
-	if (time < 0.000001) {
-		return `${(time * 1000000000).toFixed(2)} ns`;
-	} else if (time < 0.001) {
-		return `${(time * 1000000).toFixed(2)} µs`;
-	} else if (time < 1) {
-		return `${(time * 1000).toFixed(2)} ms`;
-	} else {
-		return `${time.toFixed(2)} s`;
-	}
-};
 
 function csvReport(results) {
 	const primaryMetric =
@@ -24,32 +11,23 @@ function csvReport(results) {
 	const header = `name,${primaryMetric === "opsSec" ? "ops/sec" : "total time"},samples,plugins,min,max\n`;
 	process.stdout.write(header);
 
-	for (const result of results) {
-		process.stdout.write(`${result.name},`);
+	const output = summarize(results);
+
+	for (const entry of output) {
+		process.stdout.write(`${entry.name},`);
 
 		if (primaryMetric === "opsSec") {
-			const opsSecReported =
-				result.opsSec < 100
-					? result.opsSec.toFixed(2)
-					: result.opsSec.toFixed(0);
-			process.stdout.write(`"${formatter.format(opsSecReported)}",`);
+			process.stdout.write(`"${formatter.format(entry.opsSec)}",`);
 		} else {
-			// primaryMetric === 'totalTime'
-			process.stdout.write(`"${formatTimeForCSV(result.totalTime)}",`);
+			process.stdout.write(`${entry.totalTimeFormatted},`);
 		}
 
-		process.stdout.write(`${result.histogram.samples},`);
-
-		process.stdout.write(
-			`"${result.plugins
-				.filter((p) => p.report)
-				.map((p) => p.report)
-				.join(",")}",`,
-		);
+		process.stdout.write(`${entry.runsSampled},`);
+		process.stdout.write(`"${entry.plugins.join(",")}",`);
 
 		// For test compatibility, format min/max in microseconds
-		const minInUs = result.histogram.min / 1000;
-		const maxInUs = result.histogram.max / 1000;
+		const minInUs = entry.min / 1000;
+		const maxInUs = entry.max / 1000;
 		process.stdout.write(`${minInUs.toFixed(2)}us,`);
 		process.stdout.write(`${maxInUs.toFixed(2)}us\n`);
 	}

--- a/lib/reporter/html.js
+++ b/lib/reporter/html.js
@@ -1,6 +1,7 @@
 const { platform, arch, availableParallelism, totalmem } = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
+const { summarize } = require("../utils/analyze");
 
 const formatter = Intl.NumberFormat(undefined, {
 	notation: "standard",
@@ -11,22 +12,6 @@ const timer = Intl.NumberFormat(undefined, {
 	minimumFractionDigits: 3,
 	maximumFractionDigits: 3,
 });
-
-const formatTime = (time) => {
-	if (time < 0.000001) {
-		// Less than 1 microsecond, show in nanoseconds
-		return `${(time * 1000000000).toFixed(2)} ns`;
-	} else if (time < 0.001) {
-		// Less than 1 millisecond, show in microseconds
-		return `${(time * 1000000).toFixed(2)} µs`;
-	} else if (time < 1) {
-		// Less than 1 second, show in milliseconds
-		return `${(time * 1000).toFixed(2)} ms`;
-	} else {
-		// 1 second or more, show in seconds
-		return `${time.toFixed(2)} s`;
-	}
-};
 
 const valueToDuration = (maxValue, value, isTimeBased, scalingFactor = 10) => {
 	const normalizedValue = isTimeBased ? maxValue / value : value / maxValue;
@@ -92,30 +77,31 @@ const templatePath = path.join(__dirname, "template.html");
 const template = fs.readFileSync(templatePath, "utf8");
 
 function htmlReport(results) {
+	const summary = summarize(results);
 	const primaryMetric =
 		results[0]?.opsSec !== undefined ? "opsSec" : "totalTime";
 	let durations;
 
 	if (primaryMetric === "opsSec") {
-		const maxOpsSec = Math.max(...results.map((b) => b.opsSec));
-		durations = results.map((r) => ({
+		const maxOpsSec = Math.max(...summary.map((b) => b.opsSec));
+		durations = summary.map((r) => ({
 			name: r.name.replaceAll(" ", "-"),
 			duration: valueToDuration(maxOpsSec, r.opsSec, false),
 			metricValueFormatted: formatter.format(r.opsSec),
 			metricUnit: "ops/sec",
-			minFormatted: timer.format(r.histogram.min), // Use timer for ns format
-			maxFormatted: timer.format(r.histogram.max),
+			minFormatted: timer.format(r.min), // Use timer for ns format
+			maxFormatted: timer.format(r.max),
 		}));
 	} else {
 		// metric === 'totalTime'
-		const maxTotalTime = Math.max(...results.map((b) => b.totalTime));
-		durations = results.map((r) => ({
+		const maxTotalTime = Math.max(...summary.map((b) => b.totalTime));
+		durations = summary.map((r) => ({
 			name: r.name.replaceAll(" ", "-"),
 			duration: valueToDuration(maxTotalTime, r.totalTime, true),
-			metricValueFormatted: formatTime(r.totalTime),
+			metricValueFormatted: r.totalTimeFormatted,
 			metricUnit: "total time",
-			minFormatted: timer.format(r.histogram.min), // Use timer for ns format
-			maxFormatted: timer.format(r.histogram.max),
+			minFormatted: timer.format(r.min), // Use timer for ns format
+			maxFormatted: timer.format(r.max),
 		}));
 	}
 

--- a/lib/reporter/json.js
+++ b/lib/reporter/json.js
@@ -1,46 +1,16 @@
-const { timer } = require("../clock");
-
-// Helper function to format time in appropriate units
-const formatTime = (time) => {
-	if (time < 0.000001) {
-		// Less than 1 microsecond, show in nanoseconds
-		return `${(time * 1000000000).toFixed(2)} ns`;
-	} else if (time < 0.001) {
-		// Less than 1 millisecond, show in microseconds
-		return `${(time * 1000000).toFixed(2)} µs`;
-	} else if (time < 1) {
-		// Less than 1 second, show in milliseconds
-		return `${(time * 1000).toFixed(2)} ms`;
-	} else {
-		// 1 second or more, show in seconds
-		return `${time.toFixed(2)} s`;
-	}
-};
+const { summarize } = require("../utils/analyze");
 
 function jsonReport(results) {
-	const output = results.map((result) => {
-		const baseResult = {
-			name: result.name,
-			runsSampled: result.histogram.samples,
-			min: timer.format(result.histogram.min),
-			max: timer.format(result.histogram.max),
-			// Report anything the plugins returned
-			plugins: result.plugins.map((p) => p.report).filter(Boolean),
-		};
-
-		if (result.opsSec !== undefined) {
-			const opsSecReported =
-				result.opsSec < 100
-					? result.opsSec.toFixed(2)
-					: result.opsSec.toFixed(0);
-			baseResult.opsSec = Number(opsSecReported);
-		} else if (result.totalTime !== undefined) {
-			baseResult.totalTime = result.totalTime; // Total time in seconds
-			baseResult.totalTimeFormatted = formatTime(result.totalTime);
-		}
-
-		return baseResult;
-	});
+	const output = summarize(results).map((result) => ({
+		name: result.name,
+		runsSampled: result.runsSampled,
+		min: result.minFormatted,
+		max: result.maxFormatted,
+		plugins: result.plugins.map((p) => p.report).filter(Boolean),
+		opsSec: result.opsSec,
+		totalTime: result.totalTime,
+		totalTimeFormatted: result.totalTimeFormatted,
+	}));
 
 	console.log(JSON.stringify(output, null, 2));
 }

--- a/lib/utils/analyze.js
+++ b/lib/utils/analyze.js
@@ -1,3 +1,5 @@
+const { timer } = require("../clock");
+
 function analyze(results, sorted = true) {
 	const baselineResult = results.find((result) => result.baseline);
 
@@ -59,6 +61,57 @@ function analyze(results, sorted = true) {
 	return output;
 }
 
+const formatter = Intl.NumberFormat(undefined, {
+	notation: "standard",
+	maximumFractionDigits: 2,
+});
+
+// Helper function to format time in appropriate units
+const formatTime = (time) => {
+	if (time < 0.000001) {
+		// Less than 1 microsecond, show in nanoseconds
+		return `${(time * 1000000000).toFixed(2)} ns`;
+	} else if (time < 0.001) {
+		// Less than 1 millisecond, show in microseconds
+		return `${(time * 1000000).toFixed(2)} µs`;
+	} else if (time < 1) {
+		// Less than 1 second, show in milliseconds
+		return `${(time * 1000).toFixed(2)} ms`;
+	} else {
+		// 1 second or more, show in seconds
+		return `${time.toFixed(2)} s`;
+	}
+};
+
+function summarize(results) {
+	return results.map((result) => {
+		const baseResult = {
+			name: result.name,
+			runsSampled: result.histogram.samples,
+			min: result.histogram.min,
+			max: result.histogram.max,
+			minFormatted: timer.format(result.histogram.min), // Use timer for ns format
+			maxFormatted: timer.format(result.histogram.max),
+			// Report anything the plugins returned
+			plugins: result.plugins.map((p) => p.report).filter(Boolean),
+		};
+
+		if (result.opsSec !== undefined) {
+			const opsSecReported =
+				result.opsSec < 100
+					? result.opsSec.toFixed(2)
+					: result.opsSec.toFixed(0);
+			baseResult.opsSec = Number(opsSecReported);
+		} else if (result.totalTime !== undefined) {
+			baseResult.totalTime = result.totalTime; // Total time in seconds
+			baseResult.totalTimeFormatted = formatTime(result.totalTime);
+		}
+
+		return baseResult;
+	});
+}
+
 module.exports = {
 	analyze,
+	summarize,
 };

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -12,7 +12,7 @@ const {
 	textReport,
 } = require("../lib");
 
-const { analyze } = require("../lib/utils/analyze.js");
+const { analyze, summarize } = require("../lib/utils/analyze.js");
 
 describe("chartReport outputs benchmark results as a bar chart", async (t) => {
 	let output = "";
@@ -287,7 +287,7 @@ describe("prettyReport outputs a beautiful report", async (t) => {
 	});
 });
 
-describe("analyse", async (t) => {
+describe("analyze", async (t) => {
 	let analysis;
 
 	before(async () => {
@@ -320,6 +320,61 @@ describe("analyse", async (t) => {
 
 	it("annotates the slowest result", () => {
 		assert.equal(analysis[0].slowest, true, "slowest result");
+	});
+});
+
+describe("summarize", async (t) => {
+	let results;
+
+	before(async () => {
+		// Create a new Suite with the pretty reporter
+		const suite = new Suite({});
+
+		// Add benchmarks with one being the baseline
+		suite
+			.add("baseline-test", { baseline: true }, () => {
+				// Medium-speed operation
+				for (let i = 0; i < 10000; i++) {}
+			})
+			.add("other-test", () => {
+				// Faster operation
+				for (let i = 0; i < 1000; i++) {}
+			})
+			.add("faster-test", () => {
+				// Slower operation
+				for (let i = 0; i < 100; i++) {}
+			});
+
+		// Run the suite
+		results = await suite.run();
+	});
+
+	it("should contain the required benchmark fields", () => {
+		const data = summarize(results);
+
+		// We expect the two benchmarks we added: 'single with matcher' and 'Multiple replaces'
+		assert.strictEqual(data.length, 3, "Should have results for 3 benchmarks");
+
+		for (const entry of data) {
+			// Ensure each entry has expected keys
+			assert.ok(typeof entry.name === "string", "name should be a string");
+			assert.ok(typeof entry.opsSec === "number", "opsSec should be a number");
+			assert.ok(
+				typeof entry.runsSampled === "number",
+				"runsSampled should be a number",
+			);
+			assert.ok(typeof entry.min === "number", "min should be a number");
+			assert.ok(typeof entry.max === "number", "max should be a number");
+			assert.ok(
+				typeof entry.minFormatted === "string",
+				"minFormatted should be a string (formatted time)",
+			);
+			assert.ok(
+				typeof entry.maxFormatted === "string",
+				"maxFormatted should be a string (formatted time)",
+			);
+			assert.ok(Array.isArray(entry.plugins), "plugins should be an array");
+		}
 	});
 });
 


### PR DESCRIPTION
In trying to figure out how to use the json reporter more like the html reporter, my eye was drawn back to some duplicated code my IDE has been complaining to me about for some time.

There's a spot in the code where the CSV format chose one fixed format and the json picked a 'human' format. I suspect Excel does not want to deal with a spread of units in a single column so that makes sense.  But I sort of wonder if the same isn't also true of the json format. Why generate JSON if it is not meant to be consumed programatically instead of by humans?

This could be considered preparatory work for #119 