### PR TITLE
Move lint after unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "lib/index.js",
 	"types": "index.d.ts",
 	"scripts": {
-		"test": "npm run lint:ci && c8 node --test --allow-natives-syntax --expose-gc",
+		"test": "c8 node --test --allow-natives-syntax --expose-gc && npm run lint:ci",
 		"test:types": "tsd -f types/types.test-d.ts",
 		"lint": "biome lint .",
 		"lint:ci": "biome ci .",


### PR DESCRIPTION
It is disruptive to code-build-test cycles to run lint on code that may still be generating red tests. This is especially annoying when you're adding or removing arguments to functions and the linter is blocking you over linefeeds when you don't even know if the code works yet.

Should block PRs, not unit test runs.