### PR TITLE
Narrow the bar display by another couple of characters

### DIFF
--- a/lib/reporter/chart.js
+++ b/lib/reporter/chart.js
@@ -64,7 +64,7 @@ function drawBar(
 
 	const displayedSamples = `${styleText(["yellow"], samples.toString().padStart(2))} samples`;
 
-	return `${label} | ${bar} | ${displayedValue} ${displayedMetric} | ${displayedSamples} ${comment}\n`;
+	return `${label} ▏${bar}▕ ${displayedValue} ${displayedMetric} | ${displayedSamples} ${comment}\n`;
 }
 
 const formatter = Intl.NumberFormat(undefined, {

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -113,7 +113,7 @@ describe("chartReport", () => {
 		});
 
 		it("should pad out benchmark names", () => {
-			assert.ok(output.includes("oong | "));
+			assert.ok(output.includes("oong ▏█"));
 			assert.ok(output.includes("multiple replaces".padEnd(51)));
 		});
 	});
@@ -534,7 +534,7 @@ describe("baseline comparisons", async (t) => {
 
 		it("can set a specific column width", () => {
 			const summary = output.split("Summary (vs. baseline):")[1];
-			assert.ok(summary.includes("baseline-test                  |"));
+			assert.ok(summary.includes("baseline-test                  ▏"));
 		});
 	});
 });


### PR DESCRIPTION
By leveraging a bit more ANSI block character trickery.

Before and after:
```
test 1                                        | █████████████████████████ | 120,782,882 ops/sec | 10 samples 
test 1                                        ▏█████████████████████████▕ 121,270,307 ops/sec | 11 samples 
```

I've previously posted two other PRs with a similar motive: The right hand side of the chart output is more actionable than the left. Therefore anything I can do to shift this farther left so that clipping or line wrapping doesn't tank your ability to scan for problems, is worth doing.

This is probably the last such improvement that can be made. The column widths can already be adjusted, and this is the last of the whitespace that is likely worth touching, with the possible exception of "120,782,882 ops/sec" -> "120,782,882/sec". 

