### PR TITLE
fix: Clock inaccuracy in libuv is causing flaky tests.

### DIFF
--- a/test/time-mode.js
+++ b/test/time-mode.js
@@ -52,7 +52,7 @@ describe("Time-based Benchmarking", () => {
 		// Verify the time is approximately correct (allow for some overhead)
 		const measuredTime = results[0].totalTime * 1000; // Convert to ms
 		assert.ok(
-			measuredTime >= delayTime && measuredTime < delayTime + 20,
+			measuredTime >= delayTime - 0.999 && measuredTime < delayTime + 20,
 			`Measured time (${measuredTime}ms) should be close to expected delay (${delayTime}ms)`,
 		);
 


### PR DESCRIPTION
github.com/libuv/libuv/issues/4773

This isn't fixed until Node 24.?? so your tests will be flaky as long as you're validating on 20 and 22