### PR TITLE
Localize op/sec in text reporter

### DIFF
--- a/lib/reporter/text.js
+++ b/lib/reporter/text.js
@@ -73,14 +73,14 @@ function toText(results, options = {}) {
 }
 
 const numberFormat = new Intl.NumberFormat(
-	process.env.BENCH_NODE_LOCALE_ID || 'en-US',
-	{ 
-		style: 'decimal',
-		useGrouping: true
-	}
-)
+	process.env.BENCH_NODE_LOCALE_ID || "en-US",
+	{
+		style: "decimal",
+		useGrouping: true,
+	},
+);
 function localize(number) {
-	return numberFormat.format(number)
+	return numberFormat.format(number);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR localizes the ops/sec figure in the text reporter output. When I ran `npm run test` to look for a test to update, I got a lot of errors that seem unrelated (e.g. a bunch of complaints about `--allow-natives-syntax` not being provided).