### PR TITLE
--test flag propagation appears to be fixed in node.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24, 25.4.0]
+        node-version: [18, 20, 22, 24, 25]
 
     env:
       CI: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:24.6-trixie-slim
+FROM node:24-trixie-slim
 
 RUN apt update && apt install git -y


### PR DESCRIPTION
24.13.1 seems to have the fix.